### PR TITLE
Move HTML parsing to own file

### DIFF
--- a/dist/to-markdown.js
+++ b/dist/to-markdown.js
@@ -13,13 +13,8 @@ var toMarkdown;
 var converters;
 var mdConverters = require('./lib/md-converters');
 var gfmConverters = require('./lib/gfm-converters');
+var HtmlParser = require('./lib/html-parser');
 var collapse = require('collapse-whitespace');
-
-/*
- * Set up window and document for Node.js
- */
-
-var _window = (typeof window !== 'undefined' ? window : this);
 
 /*
  * Utilities
@@ -49,75 +44,6 @@ var voids = [
 function isVoid(node) {
   return voids.indexOf(node.nodeName.toLowerCase()) !== -1;
 }
-
-/*
- * Parsing HTML strings
- */
-
-function canParseHtml() {
-  var Parser = _window.DOMParser, canParse = false;
-
-  // Adapted from https://gist.github.com/1129031
-  // Firefox/Opera/IE throw errors on unsupported types
-  try {
-    // WebKit returns null on unsupported types
-    if (new Parser().parseFromString('', 'text/html')) {
-      canParse = true;
-    }
-  } catch (e) {}
-  return canParse;
-}
-
-function createHtmlParser() {
-  var Parser = function () {};
-
-  if (typeof document === 'undefined') {
-    var jsdom = require('jsdom');
-    Parser.prototype.parseFromString = function (string) {
-      return jsdom.jsdom(string, {
-        features: {
-          FetchExternalResources: [],
-          ProcessExternalResources: false
-        }
-      });
-    };
-  } else {
-    var useActiveX = false;
-    try {
-      var testDoc = document.implementation.createHTMLDocument('');
-      testDoc.open();
-    } catch (e) {
-      if (window.ActiveXObject) {
-        // IE9
-        useActiveX = true;
-      } // otherwise this will fail - badly (shouldn't happen in any browser though)
-    }
-
-    if (!useActiveX) {
-      Parser.prototype.parseFromString = function (string) {
-        // this is the most correct parsing method
-        var newDoc = document.implementation.createHTMLDocument('');
-        newDoc.open();
-        newDoc.write(string);
-        newDoc.close();
-        return newDoc;
-      };
-    } else {
-      Parser.prototype.parseFromString = function (string) {
-        // correct fallback for IE9
-        var newDoc = new ActiveXObject('htmlfile');
-        newDoc.designMode = "on"; // this disables on-page scripts... yes - I know
-        newDoc.open();
-        newDoc.write(string);
-        newDoc.close();
-        return newDoc;
-      };
-    }
-  }
-  return Parser;
-}
-
-var HtmlParser = canParseHtml() ? _window.DOMParser : createHtmlParser();
 
 function htmlToDom(string) {
   var tree = new HtmlParser().parseFromString(string, 'text/html');
@@ -308,7 +234,7 @@ toMarkdown.outer = outer;
 
 module.exports = toMarkdown;
 
-},{"./lib/gfm-converters":2,"./lib/md-converters":3,"collapse-whitespace":6,"jsdom":5}],2:[function(require,module,exports){
+},{"./lib/gfm-converters":2,"./lib/html-parser":3,"./lib/md-converters":4,"collapse-whitespace":7}],2:[function(require,module,exports){
 'use strict';
 
 function cell(content, node) {
@@ -421,6 +347,82 @@ module.exports = [
 ];
 
 },{}],3:[function(require,module,exports){
+/*
+ * Set up window for Node.js
+ */
+
+var _window = (typeof window !== 'undefined' ? window : this);
+
+/*
+ * Parsing HTML strings
+ */
+
+function canParseHtmlNatively () {
+  var Parser = _window.DOMParser
+  var canParse = false;
+
+  // Adapted from https://gist.github.com/1129031
+  // Firefox/Opera/IE throw errors on unsupported types
+  try {
+    // WebKit returns null on unsupported types
+    if (new Parser().parseFromString('', 'text/html')) {
+      canParse = true;
+    }
+  } catch (e) {}
+
+  return canParse;
+}
+
+function createHtmlParser () {
+  var Parser = function () {};
+  
+  // For Node.js environments
+  if (typeof document === 'undefined') {
+    var jsdom = require('jsdom');
+    Parser.prototype.parseFromString = function (string) {
+      return jsdom.jsdom(string, {
+        features: {
+          FetchExternalResources: [],
+          ProcessExternalResources: false
+        }
+      });
+    };
+  } else {
+    Parser.prototype.parseFromString = function (string) {
+      var doc;
+
+      if (!shouldUseActiveX()) {
+        doc = document.implementation.createHTMLDocument('');
+      } else {
+        doc = new ActiveXObject('htmlfile');
+        doc.designMode = 'on'; // disable on-page scripts
+      }
+
+      doc.open();
+      doc.write(string);
+      doc.close();
+
+      return doc;
+    };
+  }
+  return Parser;
+}
+
+function shouldUseActiveX () {
+  var useActiveX = false;
+
+  try {
+    document.implementation.createHTMLDocument('').open();
+  } catch (e) {
+    if (window.ActiveXObject) useActiveX = true;
+  }
+
+  return useActiveX;
+}
+
+module.exports = canParseHtmlNatively() ? _window.DOMParser : createHtmlParser()
+
+},{"jsdom":6}],4:[function(require,module,exports){
 'use strict';
 
 module.exports = [
@@ -572,7 +574,7 @@ module.exports = [
     }
   }
 ];
-},{}],4:[function(require,module,exports){
+},{}],5:[function(require,module,exports){
 /**
  * This file automatically generated from `build.js`.
  * Do not manually edit.
@@ -616,9 +618,9 @@ module.exports = [
   "video"
 ];
 
-},{}],5:[function(require,module,exports){
-
 },{}],6:[function(require,module,exports){
+
+},{}],7:[function(require,module,exports){
 'use strict';
 
 var voidElements = require('void-elements');
@@ -756,7 +758,7 @@ function next(prev, current) {
 
 module.exports = collapseWhitespace;
 
-},{"block-elements":4,"void-elements":7}],7:[function(require,module,exports){
+},{"block-elements":5,"void-elements":8}],8:[function(require,module,exports){
 /**
  * This file automatically generated from `pre-publish.js`.
  * Do not manually edit.

--- a/dist/to-markdown.js
+++ b/dist/to-markdown.js
@@ -388,22 +388,24 @@ function createHtmlParser () {
       });
     };
   } else {
-    Parser.prototype.parseFromString = function (string) {
-      var doc;
-
-      if (!shouldUseActiveX()) {
-        doc = document.implementation.createHTMLDocument('');
-      } else {
-        doc = new ActiveXObject('htmlfile');
+    if (!shouldUseActiveX()) {
+      Parser.prototype.parseFromString = function (string) {
+        var doc = document.implementation.createHTMLDocument('');
+        doc.open();
+        doc.write(string);
+        doc.close();
+        return doc;
+      };
+    } else {
+      Parser.prototype.parseFromString = function (string) {
+        var doc = new ActiveXObject('htmlfile');
         doc.designMode = 'on'; // disable on-page scripts
-      }
-
-      doc.open();
-      doc.write(string);
-      doc.close();
-
-      return doc;
-    };
+        doc.open();
+        doc.write(string);
+        doc.close();
+        return doc;
+      };
+    }
   }
   return Parser;
 }

--- a/lib/html-parser.js
+++ b/lib/html-parser.js
@@ -39,22 +39,24 @@ function createHtmlParser () {
       });
     };
   } else {
-    Parser.prototype.parseFromString = function (string) {
-      var doc;
-
-      if (!shouldUseActiveX()) {
-        doc = document.implementation.createHTMLDocument('');
-      } else {
-        doc = new ActiveXObject('htmlfile');
+    if (!shouldUseActiveX()) {
+      Parser.prototype.parseFromString = function (string) {
+        var doc = document.implementation.createHTMLDocument('');
+        doc.open();
+        doc.write(string);
+        doc.close();
+        return doc;
+      };
+    } else {
+      Parser.prototype.parseFromString = function (string) {
+        var doc = new ActiveXObject('htmlfile');
         doc.designMode = 'on'; // disable on-page scripts
-      }
-
-      doc.open();
-      doc.write(string);
-      doc.close();
-
-      return doc;
-    };
+        doc.open();
+        doc.write(string);
+        doc.close();
+        return doc;
+      };
+    }
   }
   return Parser;
 }

--- a/lib/html-parser.js
+++ b/lib/html-parser.js
@@ -1,0 +1,74 @@
+/*
+ * Set up window for Node.js
+ */
+
+var _window = (typeof window !== 'undefined' ? window : this);
+
+/*
+ * Parsing HTML strings
+ */
+
+function canParseHtmlNatively () {
+  var Parser = _window.DOMParser
+  var canParse = false;
+
+  // Adapted from https://gist.github.com/1129031
+  // Firefox/Opera/IE throw errors on unsupported types
+  try {
+    // WebKit returns null on unsupported types
+    if (new Parser().parseFromString('', 'text/html')) {
+      canParse = true;
+    }
+  } catch (e) {}
+
+  return canParse;
+}
+
+function createHtmlParser () {
+  var Parser = function () {};
+  
+  // For Node.js environments
+  if (typeof document === 'undefined') {
+    var jsdom = require('jsdom');
+    Parser.prototype.parseFromString = function (string) {
+      return jsdom.jsdom(string, {
+        features: {
+          FetchExternalResources: [],
+          ProcessExternalResources: false
+        }
+      });
+    };
+  } else {
+    Parser.prototype.parseFromString = function (string) {
+      var doc;
+
+      if (!shouldUseActiveX()) {
+        doc = document.implementation.createHTMLDocument('');
+      } else {
+        doc = new ActiveXObject('htmlfile');
+        doc.designMode = 'on'; // disable on-page scripts
+      }
+
+      doc.open();
+      doc.write(string);
+      doc.close();
+
+      return doc;
+    };
+  }
+  return Parser;
+}
+
+function shouldUseActiveX () {
+  var useActiveX = false;
+
+  try {
+    document.implementation.createHTMLDocument('').open();
+  } catch (e) {
+    if (window.ActiveXObject) useActiveX = true;
+  }
+
+  return useActiveX;
+}
+
+module.exports = canParseHtmlNatively() ? _window.DOMParser : createHtmlParser()


### PR DESCRIPTION
This PR moves the HTML parser code, including your fixes for malformed docs and IE9, into its own file to tidy it up a bit.

Hopefully this should come through to https://github.com/domchristie/to-markdown/pull/129 once merged.